### PR TITLE
Vasb 9658/ci changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ Before installing the developer tools, you'll need to make sure that you have tw
 
 Next, install the ViewAR CLI – a command-line tool that generates basic boilerplates of new projects with examples.
 
-`npm install -g viewar-cli` or `yarn global add viewar-cli`
+`npm install -g @viewar/cli` or `yarn global add @viewar/cli`
 
 You only need to install the ViewAR CLI once. It will alert you when it's out of date, and provide instructions on how to update it.
 
 Once installed, the CLI can be used to create a new project by running:
 
 ```
-viewar-cli init PROJECT_NAME
+@viewar/cli init PROJECT_NAME
 ```
 
 where `PROJECT_NAME` is the name of your new application. Once it's been created and the dependencies are installed, change your working directory to `PROJECT_NAME`, and start the application server by running `npm start` (or `yarn start`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "viewar-cli",
+  "name": "@viewar/cli",
   "version": "0.14.1",
   "lockfileVersion": 1,
   "requires": true,
@@ -2977,17 +2977,32 @@
       }
     },
     "cacheable-request": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.0.0.tgz",
-      "integrity": "sha512-2N7AmszH/WPPpl5Z3XMw1HAP+8d+xugnKQAeKvxFZ/04dbT/CAznqwbl+7eSr3HkwdepNwtb2yx3CAMQWvG01Q==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
+      "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
       "requires": {
         "clone-response": "^1.0.2",
-        "get-stream": "^4.0.0",
+        "get-stream": "^5.1.0",
         "http-cache-semantics": "^4.0.0",
         "keyv": "^3.0.0",
-        "lowercase-keys": "^1.0.1",
-        "normalize-url": "^3.1.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^4.1.0",
         "responselike": "^1.0.2"
+      },
+      "dependencies": {
+        "get-stream": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
+          "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "lowercase-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA=="
+        }
       }
     },
     "camelcase": {
@@ -3664,9 +3679,9 @@
       }
     },
     "defer-to-connect": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
-      "integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
+      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
     },
     "deferred-leveldown": {
       "version": "0.2.0",
@@ -5256,9 +5271,9 @@
       "dev": true
     },
     "http-cache-semantics": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.0.3.tgz",
-      "integrity": "sha512-TcIMG3qeVLgDr1TEd2XvHaTnMPwYQUQMIBLy+5pLSDKYFc7UIqj39w8EGzZkaxoLv/l2K8HaI0t5AVA+YYgUew=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
+      "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ=="
     },
     "http-signature": {
       "version": "1.2.0",
@@ -8065,9 +8080,9 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="
     },
     "normalize-url": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
-      "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
+      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ=="
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -8303,20 +8318,20 @@
       "dev": true
     },
     "package-json": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.3.0.tgz",
-      "integrity": "sha512-XO7WS3EEXd48vmW633Y97Mh9xuENFiOevI9G+ExfTG/k6xuY9cBd3fxkAoDMSEsNZXasaVJIJ1rD/n7GMf18bA==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-6.5.0.tgz",
+      "integrity": "sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==",
       "requires": {
         "got": "^9.6.0",
-        "registry-auth-token": "^3.4.0",
+        "registry-auth-token": "^4.0.0",
         "registry-url": "^5.0.0",
-        "semver": "^5.6.0"
+        "semver": "^6.2.0"
       },
       "dependencies": {
         "semver": {
-          "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-          "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -8817,12 +8832,11 @@
       }
     },
     "registry-auth-token": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
-      "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
+      "integrity": "sha512-9bKS7nTl9+/A1s7tnPeGrUpRcVY+LUh7bfFgzpndALdPfXQBfQV77rQVtqgUV3ti4vc/Ik81Ex8UJDWDQ12zQA==",
       "requires": {
-        "rc": "^1.1.6",
-        "safe-buffer": "^5.0.1"
+        "rc": "^1.2.8"
       }
     },
     "registry-url": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "viewar-cli",
+  "name": "@viewar/cli",
   "version": "0.14.1",
   "description": "ViewAR SDK Command Line Interface",
   "main": "dist/index.js",
@@ -40,6 +40,7 @@
     "node": ">=10.13.0"
   },
   "bin": {
+    "@viewar/cli": "dist/index.js",
     "viewar-cli": "dist/index.js",
     "viewar": "dist/index.js"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,7 +14,7 @@ export default {
     banner,
     file: 'dist/index.js',
     format: 'cjs',
-    name: 'viewar-cli',
+    name: '@viewar/cli',
   },
   plugins: [
     shebang(),

--- a/src/cli.js
+++ b/src/cli.js
@@ -28,6 +28,10 @@ export default () => {
     program.version(currentVersion);
     program.option('-l, --log', 'Advanced error logging');
     program.option('-s, --server', 'Log errors to server');
+    program.option(
+      '-ci, --ci',
+      'Called from within a CI (special deploy handling)'
+    );
 
     program
       .command('init [folder] [type] [user-email]')
@@ -81,7 +85,7 @@ export default () => {
     ) {
       if (program.args.length) {
         logger.logError(
-          `viewar-cli: '${program.args[0]}' is not a viewar-cli command.`,
+          `@viewar/cli: '${program.args[0]}' is not a @viewar/cli command.`,
           false
         );
       }

--- a/src/cli.js
+++ b/src/cli.js
@@ -29,8 +29,8 @@ export default () => {
     program.option('-l, --log', 'Advanced error logging');
     program.option('-s, --server', 'Log errors to server');
     program.option(
-      '-ci, --ci',
-      'Called from within a CI (special deploy handling)'
+      '-f, --force',
+      'Force deployment of already existing app versions.'
     );
 
     program

--- a/src/commands/deploy.js
+++ b/src/commands/deploy.js
@@ -4,6 +4,7 @@ const fs = require('fs');
 const shell = require('shelljs');
 const request = require('request-promise');
 const emojic = require('emojic');
+const program = require('commander');
 
 import exitWithError from '../common/exit-with-error';
 import zipDirectory from '../common/zip-dir';
@@ -15,8 +16,13 @@ import {
 } from '../common/urls';
 import { cliConfigPath } from '../common/constants';
 import logger from '../logger/logger';
+import { exit } from 'process';
 
 export default async (appId, appVersion, tags = '') => {
+  const ci = program.args.ci;
+  console.log(ci, program.args);
+  return;
+
   logger.setInfo('deploy', {
     appId,
     appVersion,
@@ -26,7 +32,7 @@ export default async (appId, appVersion, tags = '') => {
   // Show error if app id is set but no app version.
   if (appId && !appVersion) {
     await exitWithError(
-      `Missing app version! Syntax: viewar-cli deploy <appId> <appVersion>`,
+      `Missing app version! Syntax: @viewar/cli deploy <appId> <appVersion>`,
       false
     );
   }

--- a/src/commands/init.js
+++ b/src/commands/init.js
@@ -84,14 +84,12 @@ export default async (directory, projectType, userEmail) => {
 
   if (userEmail && !enteredUser) {
     await exitWithError(
-      `User with email ${userEmail} is not logged in!  Run viewar-cli whoami to see a list of logged in users or run viewar-cli login to login as a different user.`
+      `User with email ${userEmail} is not logged in!  Run @viewar/cli whoami to see a list of logged in users or run @viewar/cli login to login as a different user.`
     );
   }
 
   console.log(
-    chalk`\n ${
-      emojic.wave
-    }  Welcome to the ViewAR App initialization process!\n`
+    chalk`\n ${emojic.wave}  Welcome to the ViewAR App initialization process!\n`
   );
 
   const user = enteredUser

--- a/src/common/check-version.js
+++ b/src/common/check-version.js
@@ -9,14 +9,22 @@ export default (timeout = 2000) => {
 
   return Promise.race([
     new Promise(resolve => setTimeout(resolve, timeout)),
-    latestVersion('@viewar/cli').then(version => {
-      if (!semver.satisfies(currentVersion, `>=${version}`)) {
-        console.log(
-          chalk.red(
-            `${emojic.exclamation}  Your installed @viewar/cli version (${currentVersion}) is not up to date.\nPlease install the latest version (${version}) from npm.\n\thttps://www.npmjs.com/package/@viewar/cli.`
-          )
-        );
-      }
-    }),
+    latestVersion('@viewar/cli')
+      .then(version => {
+        if (!semver.satisfies(currentVersion, `>=${version}`)) {
+          console.log(
+            chalk.red(
+              `${emojic.exclamation}  Your installed @viewar/cli version (${currentVersion}) is not up to date.\nPlease install the latest version (${version}) from npm.\n\thttps://www.npmjs.com/package/@viewar/cli.`
+            )
+          );
+        }
+      })
+      .catch(e => {
+        // During development a PackageNotFoundError can occur.
+        // Ignore this error and log all others to console.
+        if (e.name !== 'PackageNotFoundError') {
+          console.error(`Unhandled exception in "latest-version".`, e);
+        }
+      }),
   ]);
 };

--- a/src/common/check-version.js
+++ b/src/common/check-version.js
@@ -9,13 +9,11 @@ export default (timeout = 2000) => {
 
   return Promise.race([
     new Promise(resolve => setTimeout(resolve, timeout)),
-    latestVersion('viewar-cli').then(version => {
+    latestVersion('@viewar/cli').then(version => {
       if (!semver.satisfies(currentVersion, `>=${version}`)) {
         console.log(
           chalk.red(
-            `${
-              emojic.exclamation
-            }  Your installed viewar-cli version (${currentVersion}) is not up to date.\nPlease install the latest version (${version}) from npm.\n\thttps://www.npmjs.com/package/viewar-cli.`
+            `${emojic.exclamation}  Your installed @viewar/cli version (${currentVersion}) is not up to date.\nPlease install the latest version (${version}) from npm.\n\thttps://www.npmjs.com/package/@viewar/cli.`
           )
         );
       }

--- a/src/common/urls.js
+++ b/src/common/urls.js
@@ -9,9 +9,10 @@ export const getActivateUrl = (
   appId,
   version,
   appToken,
+  force = false,
   dryRun = false
 ) =>
-  `http://dev2.viewar.com/api40/activateAppfilesUpload/token:${token}/bundleIdentifier:${appId}/version:${version}/appFiles:${appToken}/dryRun:${dryRun}`;
+  `http://dev2.viewar.com/api40/activateAppfilesUpload/token:${token}/bundleIdentifier:${appId}/version:${version}/appFiles:${appToken}/dryRun:${dryRun}/supportsForce:${true}/force:${force}`;
 
 export const getUploadBundleUrl = () =>
   `http://dev2.viewar.com/api40/appfilesUpload`;

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,0 +1,13 @@
+export const getErrorMessage = (error, appId, appVersion, fallbackMessage) => {
+  switch (error) {
+    case 100:
+      return 'Authentication failed.';
+    case 101:
+      return `Version '${appVersion}' for '${appId}' already exists. Use --force to override.`;
+    case 101:
+      return `App '${appId}' not found.`;
+    case 200:
+    default:
+      return fallbackMessage ? fallbackMessage : 'Unknown error.';
+  }
+};


### PR DESCRIPTION
Updates for new CI workflow:
* Rename package to @viewar/cli
* Only allow new configuration versions per default
* Add flag -f (or --force) to allow updating existing versions
* Refactor error messages from backend dry run request